### PR TITLE
Fix typo Special Advisor

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,7 +28,7 @@ def check_password():
 
     st.warning("This app is **in development**. It is only to be used by authorized members of OSAA.", icon=":material/warning:")
 
-    st.markdown("Welcome to the Office of the Speical Advisor to Africa's Strategic Management Unit's Data App. Please enter the app password to access the data app.")
+    st.markdown("Welcome to the Office of the Special Advisor to Africa's Strategic Management Unit's Data App. Please enter the app password to access the data app.")
 
     st.text_input(
         "Password",

--- a/home.py
+++ b/home.py
@@ -9,7 +9,7 @@ with col1:
 st.warning("This app is **in development**. It is only to be used by authorized members of OSAA.", icon=":material/warning:")
 
 # st.title("SMU's Data App")
-st.markdown("Welcome to the Office of the Speical Advisor to Africa's Strategic Management Unit's Data App. The app provides a centralized tool for exploring and analyzing data from multiple sources. Use the sidebar to the left or the page links below to navigate between the data products.")
+st.markdown("Welcome to the Office of the Special Advisor to Africa's Strategic Management Unit's Data App. The app provides a centralized tool for exploring and analyzing data from multiple sources. Use the sidebar to the left or the page links below to navigate between the data products.")
 
 st.markdown("<hr>", unsafe_allow_html=True)
 st.write("")


### PR DESCRIPTION
## Summary
- fix a spelling typo in home and app pages

## Testing
- `grep -n "Special" -n app.py home.py`


------
https://chatgpt.com/codex/tasks/task_e_6840a8565b20832793456182c33cafec